### PR TITLE
:green_heart: Modernize Build CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,42 +3,43 @@ on:
   push:
     branches:
       - master
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   release:
     name: Build and publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref_name }}
           token: ${{ secrets.GH_PAT }}
+
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4
         with:
-          node-version: 14
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          node-version: 22
+          cache: npm
+
       - name: Install dependencies
         run: npm ci
+
       - name: Build TypeScript
         run: npm run build
+
       - name: Run tests
         run: npm run test
+
       - name: Build package
         run: npm run package
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+
       - name: Publish package
-        uses: stefanzweifel/git-auto-commit-action@v4.9.2
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: ":rocket: Deploy new version [skip ci]"
           commit_user_name: Koj Bot


### PR DESCRIPTION
## Summary
- Modernizes the master-only Build CI workflow off the retired `ubuntu-18.04` runner
- Updates checkout/setup-node/git-auto-commit actions to current major versions
- Checks out the live pushed branch ref and serializes branch-mutating builds with concurrency
- Adds the legacy OpenSSL provider only for the old `@zeit/ncc` package step, matching the local reproduction of the package build

## Test plan
- `/tmp/actionlint/actionlint .github/workflows/build.yml`
- Python YAML parse of `.github/workflows/build.yml`
- `npm test -- --runInBand`
- `npm run build`
- `NODE_OPTIONS=--openssl-legacy-provider npm run package`

Follow-up to #226: the post-merge master Build CI run stayed queued on the retired runner, so this keeps the default branch build path healthy.
